### PR TITLE
Enable retry with exponential backoff

### DIFF
--- a/events_integration_test.go
+++ b/events_integration_test.go
@@ -20,7 +20,7 @@ func TestIntegrationEventAPI_Get(t *testing.T) {
 	defer helperDeleteEventTypes(t, expected)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	eventAPI := NewEventAPI(client)
+	eventAPI := NewEventAPI(client, &EventOptions{Retry: true})
 
 	t.Run("fail not found", func(t *testing.T) {
 		_, err := eventAPI.Get("does-not-exist")
@@ -50,7 +50,7 @@ func TestIntegrationEventAPI_List(t *testing.T) {
 	defer helperDeleteEventTypes(t, expected...)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	eventAPI := NewEventAPI(client)
+	eventAPI := NewEventAPI(client, nil)
 
 	eventTypes, err := eventAPI.List()
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestIntegrationEventAPI_Create(t *testing.T) {
 	helperLoadTestData(t, "event-type-create.json", eventType)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	eventAPI := NewEventAPI(client)
+	eventAPI := NewEventAPI(client, nil)
 
 	t.Run("fail invalid event type", func(t *testing.T) {
 		err := eventAPI.Create(&EventType{Name: "foo"})
@@ -86,7 +86,7 @@ func TestIntegrationEventAPI_Update(t *testing.T) {
 	defer helperDeleteEventTypes(t, eventType)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	eventAPI := NewEventAPI(client)
+	eventAPI := NewEventAPI(client, nil)
 
 	t.Run("fail not found", func(t *testing.T) {
 		copyEventType := *eventType
@@ -121,7 +121,7 @@ func TestIntegrationEventAPI_Delete(t *testing.T) {
 	helperCreateEventTypes(t, expected)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	eventAPI := NewEventAPI(client)
+	eventAPI := NewEventAPI(client, nil)
 
 	t.Run("fail not found", func(t *testing.T) {
 		err := eventAPI.Delete("does-not-exist")

--- a/helper_test.go
+++ b/helper_test.go
@@ -46,3 +46,14 @@ func helperLoadTestData(t *testing.T, name string, target interface{}) []byte {
 	}
 	return bytes
 }
+
+func helperMakeCounter(n int) chan int {
+	counter := make(chan int)
+	go func() {
+		for i := 0; i <= n; i++ {
+			counter <- i
+		}
+		close(counter)
+	}()
+	return counter
+}

--- a/nakadi.go
+++ b/nakadi.go
@@ -34,28 +34,29 @@ type ClientOptions struct {
 	ConnectionTimeout time.Duration
 }
 
+func (o *ClientOptions) withDefaults() *ClientOptions {
+	var copyOptions ClientOptions
+	if o != nil {
+		copyOptions = *o
+	}
+	if copyOptions.ConnectionTimeout == 0 {
+		copyOptions.ConnectionTimeout = defaultTimeOut
+	}
+	return &copyOptions
+}
+
 // New creates a new Nakadi client. New receives the URL of the Nakadi instance the client should connect to.
 // In addition the second parameter options can be used to configure the behavior of the client and of all sub
 // APIs in this package. The options may be nil.
 func New(url string, options *ClientOptions) *Client {
-	var client *Client
-	if options == nil {
-		client = &Client{
-			nakadiURL: url,
-			timeout:   defaultTimeOut}
-	} else {
-		client = &Client{
-			nakadiURL:     url,
-			timeout:       options.ConnectionTimeout,
-			tokenProvider: options.TokenProvider}
+	options = options.withDefaults()
 
-		if client.timeout == 0 {
-			client.timeout = defaultTimeOut
-		}
-	}
-
-	client.httpClient = newHTTPClient(client.timeout)
-	client.httpStreamClient = newHTTPStream(client.timeout)
+	client := &Client{
+		nakadiURL:        url,
+		timeout:          options.ConnectionTimeout,
+		tokenProvider:    options.TokenProvider,
+		httpClient:       newHTTPClient(options.ConnectionTimeout),
+		httpStreamClient: newHTTPStream(options.ConnectionTimeout)}
 
 	return client
 }

--- a/nakadi_test.go
+++ b/nakadi_test.go
@@ -1,13 +1,12 @@
 package nakadi
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
-	"net/http"
-
-	"encoding/json"
-
+	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/jarcoal/httpmock.v1"
@@ -69,7 +68,7 @@ func TestClient_httpGET(t *testing.T) {
 		client := setupClient(nil)
 		httpmock.RegisterResponder("GET", url, httpmock.NewErrorResponder(assert.AnError))
 
-		err := client.httpGET(url, &body, msg)
+		err := client.httpGET(&backoff.StopBackOff{}, url, &body, msg)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -81,7 +80,7 @@ func TestClient_httpGET(t *testing.T) {
 		client.tokenProvider = func() (string, error) { return "", assert.AnError }
 		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusOK, encoded))
 
-		err := client.httpGET(url, &body, msg)
+		err := client.httpGET(&backoff.StopBackOff{}, url, &body, msg)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -95,7 +94,7 @@ func TestClient_httpGET(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, encoded), nil
 		})
 
-		err := client.httpGET(url, &body, msg)
+		err := client.httpGET(&backoff.StopBackOff{}, url, &body, msg)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"key": "value"}, body)
@@ -105,7 +104,7 @@ func TestClient_httpGET(t *testing.T) {
 		client := setupClient(nil)
 		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusOK, encoded))
 
-		err := client.httpGET(url, &body, msg)
+		err := client.httpGET(&backoff.StopBackOff{}, url, &body, msg)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"key": "value"}, body)
@@ -129,7 +128,7 @@ func TestClient_httpPUT(t *testing.T) {
 		client := setupClient(nil)
 		httpmock.RegisterResponder("PUT", url, httpmock.NewErrorResponder(assert.AnError))
 
-		_, err := client.httpPUT(url, &expected)
+		_, err := client.httpPUT(&backoff.StopBackOff{}, url, &expected)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -140,7 +139,7 @@ func TestClient_httpPUT(t *testing.T) {
 		client.tokenProvider = func() (string, error) { return "", assert.AnError }
 		httpmock.RegisterResponder("PUT", url, httpmock.NewStringResponder(http.StatusOK, ""))
 
-		_, err := client.httpPUT(url, &expected)
+		_, err := client.httpPUT(&backoff.StopBackOff{}, url, &expected)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -154,7 +153,7 @@ func TestClient_httpPUT(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, ""), nil
 		})
 
-		response, err := client.httpPUT(url, &expected)
+		response, err := client.httpPUT(&backoff.StopBackOff{}, url, &expected)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -170,7 +169,7 @@ func TestClient_httpPUT(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, ""), nil
 		})
 
-		response, err := client.httpPUT(url, &expected)
+		response, err := client.httpPUT(&backoff.StopBackOff{}, url, &expected)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -194,7 +193,7 @@ func TestClient_httpPOST(t *testing.T) {
 		client := setupClient(nil)
 		httpmock.RegisterResponder("POST", url, httpmock.NewErrorResponder(assert.AnError))
 
-		_, err := client.httpPOST(url, &expected)
+		_, err := client.httpPOST(&backoff.StopBackOff{}, url, &expected)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -205,7 +204,7 @@ func TestClient_httpPOST(t *testing.T) {
 		client.tokenProvider = func() (string, error) { return "", assert.AnError }
 		httpmock.RegisterResponder("POST", url, httpmock.NewStringResponder(http.StatusOK, ""))
 
-		_, err := client.httpPOST(url, &expected)
+		_, err := client.httpPOST(&backoff.StopBackOff{}, url, &expected)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -219,7 +218,7 @@ func TestClient_httpPOST(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, ""), nil
 		})
 
-		response, err := client.httpPOST(url, &expected)
+		response, err := client.httpPOST(&backoff.StopBackOff{}, url, &expected)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -235,7 +234,7 @@ func TestClient_httpPOST(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, ""), nil
 		})
 
-		response, err := client.httpPOST(url, &expected)
+		response, err := client.httpPOST(&backoff.StopBackOff{}, url, &expected)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -259,7 +258,7 @@ func TestClient_httpDELETE(t *testing.T) {
 		client := setupClient(nil)
 		httpmock.RegisterResponder("DELETE", url, httpmock.NewErrorResponder(assert.AnError))
 
-		err := client.httpDELETE(url, msg)
+		err := client.httpDELETE(&backoff.StopBackOff{}, url, msg)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -271,7 +270,7 @@ func TestClient_httpDELETE(t *testing.T) {
 		client.tokenProvider = func() (string, error) { return "", assert.AnError }
 		httpmock.RegisterResponder("DELETE", url, httpmock.NewStringResponder(http.StatusOK, ""))
 
-		err := client.httpDELETE(url, msg)
+		err := client.httpDELETE(&backoff.StopBackOff{}, url, msg)
 
 		require.Error(t, err)
 		assert.Regexp(t, assert.AnError, err)
@@ -285,7 +284,7 @@ func TestClient_httpDELETE(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, ""), nil
 		})
 
-		err := client.httpDELETE(url, msg)
+		err := client.httpDELETE(&backoff.StopBackOff{}, url, msg)
 
 		assert.NoError(t, err)
 	})
@@ -294,7 +293,7 @@ func TestClient_httpDELETE(t *testing.T) {
 		client := setupClient(nil)
 		httpmock.RegisterResponder("DELETE", url, httpmock.NewStringResponder(http.StatusOK, ""))
 
-		err := client.httpDELETE(url, msg)
+		err := client.httpDELETE(&backoff.StopBackOff{}, url, msg)
 
 		assert.NoError(t, err)
 	})

--- a/simple_stream.go
+++ b/simple_stream.go
@@ -15,6 +15,7 @@ import (
 type simpleStreamOpener struct {
 	client         *Client
 	subscriptionID string
+	batchLimit     int
 }
 
 func (so *simpleStreamOpener) openStream() (streamer, error) {
@@ -51,6 +52,9 @@ func (so *simpleStreamOpener) openStream() (streamer, error) {
 }
 
 func (so *simpleStreamOpener) streamURL(id string) string {
+	if so.batchLimit != 0 {
+		return fmt.Sprintf("%s/subscriptions/%s/events?batch_limit=%d", so.client.nakadiURL, id, so.batchLimit)
+	}
 	return fmt.Sprintf("%s/subscriptions/%s/events", so.client.nakadiURL, id)
 }
 

--- a/streams.go
+++ b/streams.go
@@ -19,6 +19,8 @@ type Cursor struct {
 
 // StreamOptions contains optional parameters that are used to create a StreamAPI.
 type StreamOptions struct {
+	// The maximum number of Events in each chunk (and therefore per partition) of the stream (default: 1)
+	BatchLimit int
 	// The initial (minimal) retry interval used for the exponential backoff. This value is applied for
 	// stream initialization as well as for cursor commits.
 	InitialRetryInterval time.Duration
@@ -85,7 +87,8 @@ func NewStream(client *Client, subscriptionID string, options *StreamOptions) *S
 	s := &StreamAPI{
 		opener: &simpleStreamOpener{
 			client:         client,
-			subscriptionID: subscriptionID},
+			subscriptionID: subscriptionID,
+			batchLimit:     copyOptions.BatchLimit},
 		committer: &simpleCommitter{
 			client:         client,
 			subscriptionID: subscriptionID},

--- a/streams.go
+++ b/streams.go
@@ -196,6 +196,7 @@ func (s *StreamAPI) startStream() {
 			if err != nil {
 				if err == context.Canceled {
 					stream.closeStream()
+					close(s.eventCh)
 					return
 				}
 				break

--- a/streams_integration_test.go
+++ b/streams_integration_test.go
@@ -22,7 +22,7 @@ func TestIntegrationStreamAPI(t *testing.T) {
 	defer helperDeleteSubscriptions(t, eventType, subscription)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	publishAPI := NewPublishAPI(client, eventType.Name)
+	publishAPI := NewPublishAPI(client, eventType.Name, &PublishOptions{Retry: true})
 
 	// publish events
 	for _, e := range events {

--- a/streams_integration_test.go
+++ b/streams_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegrationStreamAPI(t *testing.T) {
 	}
 
 	// stream events
-	streamAPI := NewStream(client, subscription.ID, nil)
+	streamAPI := NewStream(client, subscription.ID, &StreamOptions{BatchLimit: 2})
 	received := []DataChangeEvent{}
 	for len(received) < len(events) {
 		cursor, rawEvents, err := streamAPI.NextEvents()
@@ -40,6 +40,7 @@ func TestIntegrationStreamAPI(t *testing.T) {
 		temp := []DataChangeEvent{}
 		err = json.Unmarshal(rawEvents, &temp)
 		require.NoError(t, err)
+		assert.Len(t, temp, 2)
 		received = append(received, temp...)
 
 		err = streamAPI.CommitCursor(cursor)

--- a/streams_test.go
+++ b/streams_test.go
@@ -3,7 +3,6 @@ package nakadi
 import (
 	"context"
 	"testing"
-
 	"time"
 
 	"github.com/cenkalti/backoff"

--- a/subscriptions_integration_test.go
+++ b/subscriptions_integration_test.go
@@ -20,7 +20,7 @@ func TestIntegrationSubscriptionAPI_Get(t *testing.T) {
 	defer helperDeleteSubscriptions(t, eventType, subscriptions...)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	subAPI := NewSubscriptionAPI(client)
+	subAPI := NewSubscriptionAPI(client, &SubscriptionOptions{Retry: true})
 
 	t.Run("fail not found", func(t *testing.T) {
 		_, err := subAPI.Get("does-not-exist")
@@ -49,7 +49,7 @@ func TestIntegrationSubscriptionAPI_List(t *testing.T) {
 	defer helperDeleteSubscriptions(t, eventType, subscriptions...)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	subAPI := NewSubscriptionAPI(client)
+	subAPI := NewSubscriptionAPI(client, nil)
 
 	fetched, err := subAPI.List()
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestIntegrationSubscriptionAPI_Create(t *testing.T) {
 	helperCreateEventTypes(t, eventType)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	subAPI := NewSubscriptionAPI(client)
+	subAPI := NewSubscriptionAPI(client, nil)
 
 	t.Run("fail invalid subscription", func(t *testing.T) {
 		_, err := subAPI.Create(&Subscription{OwningApplication: "test-api"})
@@ -87,7 +87,7 @@ func TestIntegrationSubscriptionAPI_Delete(t *testing.T) {
 	defer helperDeleteSubscriptions(t, eventType, subscriptions...)
 
 	client := New(defaultNakadiURL, &ClientOptions{ConnectionTimeout: time.Second})
-	subAPI := NewSubscriptionAPI(client)
+	subAPI := NewSubscriptionAPI(client, nil)
 
 	t.Run("fail not found", func(t *testing.T) {
 		err := subAPI.Delete("does-not-exist")


### PR DESCRIPTION
**Changes**
* Implement retry for the following sub APIs
  * EventAPI
  * PublishAPI
  * SubscriptionAPI
* Improve unit test