### PR TITLE
Add Go1.9 build to travis-ci config Fixes #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 
 go:
 - 1.8
+- 1.9
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 - (cd nakadi && ./gradlew startNakadi)
 
 script:
-- go vet -race .
+- go vet -v
 - golint -set_exit_status .
 - go test -v -tags=integration -covermode=count -coverprofile=profile.cov .
 


### PR DESCRIPTION
This PR adds Go 1.9 build configuration to the travis-ci configuration.

To ensure builds continue to pass, I have removed the `-race` option from `go vet` as this is no longer supported. Issue #14 has been raised to have this restored once data race issues have been resolved.