### PR TITLE
Error not swallowed when fails to unmarshal into `aplication/problem+json`

### DIFF
--- a/events.go
+++ b/events.go
@@ -1,8 +1,8 @@
 package nakadi
 
 import (
-	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -140,12 +140,11 @@ func (e *EventAPI) Create(eventType *EventType) error {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusCreated {
-		problem := problemJSON{}
-		err := json.NewDecoder(response.Body).Decode(&problem)
+		buffer, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return errors.Wrap(err, "unable to decode response body")
+			return errors.Wrap(err, "unable to read response body")
 		}
-		return errors.Errorf("unable to create event type: %s", problem.Detail)
+		return decodeResponseToError(buffer, "unable to create event type")
 	}
 
 	return nil
@@ -160,12 +159,11 @@ func (e *EventAPI) Update(eventType *EventType) error {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		problem := problemJSON{}
-		err := json.NewDecoder(response.Body).Decode(&problem)
+		buffer, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return errors.Wrap(err, "unable to decode response body")
+			return errors.Wrap(err, "unable to read response body")
 		}
-		return errors.Errorf("unable to update event type: %s", problem.Detail)
+		return decodeResponseToError(buffer, "unable to update event type")
 	}
 
 	return nil

--- a/events_test.go
+++ b/events_test.go
@@ -42,11 +42,11 @@ func TestEventAPI_Get(t *testing.T) {
 	})
 
 	t.Run("fail decode error", func(t *testing.T) {
-		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusNotFound, ""))
+		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusNotFound, "most-likely-stacktrace"))
 
 		_, err := api.Get(expected.Name)
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to request event types: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {
@@ -95,11 +95,11 @@ func TestEventAPI_List(t *testing.T) {
 	})
 
 	t.Run("fail decode error", func(t *testing.T) {
-		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusInternalServerError, ""))
+		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusInternalServerError, "most-likely-stacktrace"))
 
 		_, err := api.List()
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to request event types: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {
@@ -237,11 +237,11 @@ func TestEventAPI_Delete(t *testing.T) {
 	})
 
 	t.Run("fail decode body", func(t *testing.T) {
-		httpmock.RegisterResponder("DELETE", url, httpmock.NewStringResponder(http.StatusNotFound, ""))
+		httpmock.RegisterResponder("DELETE", url, httpmock.NewStringResponder(http.StatusNotFound, "most-likely-stacktrace"))
 
 		err := api.Delete(name)
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to delete event type: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {

--- a/events_test.go
+++ b/events_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"time"
@@ -159,6 +160,19 @@ func TestEventAPI_Create(t *testing.T) {
 		assert.Regexp(t, "not valid", err)
 	})
 
+	t.Run("fail to read body", func(t *testing.T) {
+		responder := httpmock.ResponderFromResponse(&http.Response{
+			Status:     strconv.Itoa(http.StatusBadRequest),
+			StatusCode: http.StatusBadRequest,
+			Body:       brokenBodyReader{},
+		})
+		httpmock.RegisterResponder("POST", url, responder)
+
+		err := api.Create(eventType)
+		require.Error(t, err)
+		assert.Regexp(t, "unable to read response body", err)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		httpmock.RegisterResponder("POST", url, httpmock.Responder(func(r *http.Request) (*http.Response, error) {
 			uploaded := &EventType{}
@@ -173,7 +187,7 @@ func TestEventAPI_Create(t *testing.T) {
 	})
 }
 
-func TestEventAPI_Save(t *testing.T) {
+func TestEventAPI_Update(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -202,6 +216,19 @@ func TestEventAPI_Save(t *testing.T) {
 		err := api.Update(eventType)
 		require.Error(t, err)
 		assert.Regexp(t, "not found", err)
+	})
+
+	t.Run("fail to read body", func(t *testing.T) {
+		responder := httpmock.ResponderFromResponse(&http.Response{
+			Status:     strconv.Itoa(http.StatusBadRequest),
+			StatusCode: http.StatusBadRequest,
+			Body:       brokenBodyReader{},
+		})
+		httpmock.RegisterResponder("PUT", url, responder)
+
+		err := api.Update(eventType)
+		require.Error(t, err)
+		assert.Regexp(t, "unable to read response body", err)
 	})
 
 	t.Run("success", func(t *testing.T) {

--- a/helper_test.go
+++ b/helper_test.go
@@ -36,6 +36,15 @@ func TestProblemJSON_Marshal(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(serialized))
 }
 
+func TestErrorJSON_Marshal(t *testing.T) {
+	errJSON := &errorJSON{}
+	expected := helperLoadTestData(t, "error-json.json", errJSON)
+
+	serialized, err := json.Marshal(errJSON)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expected), string(serialized))
+}
+
 func helperLoadTestData(t *testing.T, name string, target interface{}) []byte {
 	path := filepath.Join("testdata", name)
 	bytes, err := ioutil.ReadFile(path)

--- a/helper_test.go
+++ b/helper_test.go
@@ -66,3 +66,10 @@ func helperMakeCounter(n int) chan int {
 	}()
 	return counter
 }
+
+// brokenBodyReader is an implementation of ReadCloser interface to be used for
+// mocking errors while reaing from body
+type brokenBodyReader struct{}
+
+func (brokenBodyReader) Read(p []byte) (n int, err error) { return 0, assert.AnError }
+func (brokenBodyReader) Close() error                     { return nil }

--- a/publish.go
+++ b/publish.go
@@ -3,6 +3,7 @@ package nakadi
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -151,12 +152,11 @@ func (p *PublishAPI) simplePublish(events interface{}) error {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		problem := problemJSON{}
-		err := json.NewDecoder(response.Body).Decode(&problem)
+		buffer, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return errors.Wrap(err, "unable to decode response body")
+			return errors.Wrap(err, "unable to read response body")
 		}
-		return errors.Errorf("unable to request event types: %s", problem.Detail)
+		return decodeResponseToError(buffer, "unable to request event types")
 	}
 
 	return nil

--- a/publish_test.go
+++ b/publish_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"time"
@@ -123,6 +124,19 @@ func TestPublishAPI_Publish(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Regexp(t, "not authorized", err)
+	})
+
+	t.Run("fail to read body", func(t *testing.T) {
+		responder := httpmock.ResponderFromResponse(&http.Response{
+			Status:     strconv.Itoa(http.StatusBadRequest),
+			StatusCode: http.StatusBadRequest,
+			Body:       brokenBodyReader{},
+		})
+		httpmock.RegisterResponder("POST", url, responder)
+
+		err := publishAPI.Publish(events)
+		require.Error(t, err)
+		assert.Regexp(t, "unable to read response body", err)
 	})
 
 	t.Run("success", func(t *testing.T) {

--- a/publish_test.go
+++ b/publish_test.go
@@ -77,11 +77,11 @@ func TestPublishAPI_Publish(t *testing.T) {
 		require.Error(t, err)
 		assert.Regexp(t, "unable to decode response body", err)
 
-		httpmock.RegisterResponder("POST", url, httpmock.NewStringResponder(http.StatusUnauthorized, ""))
+		httpmock.RegisterResponder("POST", url, httpmock.NewStringResponder(http.StatusUnauthorized, "most-likely-stacktrace"))
 
 		err = publishAPI.Publish(events)
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to request event types: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail multi status", func(t *testing.T) {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -3,6 +3,7 @@ package nakadi
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -114,12 +115,11 @@ func (s *SubscriptionAPI) Create(subscription *Subscription) (*Subscription, err
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
-		problem := problemJSON{}
-		err := json.NewDecoder(response.Body).Decode(&problem)
+		buffer, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to decode response body")
+			return nil, errors.Wrap(err, "unable to read response body")
 		}
-		return nil, errors.Errorf("unable to create subscription: %s", problem.Detail)
+		return nil, decodeResponseToError(buffer, "unable to create subscription")
 	}
 
 	subscription = &Subscription{}

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -43,11 +43,11 @@ func TestSubscriptionAPI_Get(t *testing.T) {
 	})
 
 	t.Run("fail decode error", func(t *testing.T) {
-		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusNotFound, ""))
+		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusNotFound, "most-likely-stacktrace"))
 
 		_, err := api.Get(expected.ID)
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to request subscription: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {
@@ -98,11 +98,11 @@ func TestSubscriptionAPI_List(t *testing.T) {
 	})
 
 	t.Run("fail decode error", func(t *testing.T) {
-		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusInternalServerError, ""))
+		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusInternalServerError, "most-likely-stacktrace"))
 
 		_, err := api.List()
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to request subscriptions: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {
@@ -163,11 +163,11 @@ func TestSubscriptionAPI_Create(t *testing.T) {
 	})
 
 	t.Run("fail decode body", func(t *testing.T) {
-		httpmock.RegisterResponder("POST", url, httpmock.NewStringResponder(http.StatusUnauthorized, ""))
+		httpmock.RegisterResponder("POST", url, httpmock.NewStringResponder(http.StatusUnauthorized, "most-likely-stacktrace"))
 
 		_, err := api.Create(subscription)
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to create subscription: most-likely-stacktrace", err)
 
 		httpmock.RegisterResponder("POST", url, httpmock.NewStringResponder(http.StatusOK, ""))
 
@@ -210,11 +210,11 @@ func TestSubscriptionAPI_Delete(t *testing.T) {
 	})
 
 	t.Run("fail decode body", func(t *testing.T) {
-		httpmock.RegisterResponder("DELETE", url, httpmock.NewStringResponder(http.StatusNotFound, ""))
+		httpmock.RegisterResponder("DELETE", url, httpmock.NewStringResponder(http.StatusNotFound, "most-likely-stacktrace"))
 
 		err := api.Delete(id)
 		require.Error(t, err)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to delete subscription: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {
@@ -254,12 +254,12 @@ func TestSubscriptionAPI_GetStats(t *testing.T) {
 
 	})
 	t.Run("fail decode error", func(t *testing.T) {
-		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusInternalServerError, ""))
+		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusInternalServerError, "most-likely-stacktrace"))
 
 		stats, err := api.GetStats(id)
 		require.Error(t, err)
 		require.Nil(t, stats)
-		assert.Regexp(t, "unable to decode response body", err)
+		assert.Regexp(t, "unable to get stats for subscription: most-likely-stacktrace", err)
 	})
 
 	t.Run("fail with problem", func(t *testing.T) {

--- a/testdata/error-json.json
+++ b/testdata/error-json.json
@@ -1,0 +1,4 @@
+{
+    "error": "unauthorized",
+    "error_description": "Full authentication is required to access this resource"
+}


### PR DESCRIPTION
Fixed case when error is swallowed when it fails to unmarshal into `aplication/problem+json`

fixes #19 