### PR TITLE
Make retry commit optional

### DIFF
--- a/streams_integration_test.go
+++ b/streams_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegrationStreamAPI(t *testing.T) {
 	}
 
 	// stream events
-	streamAPI := NewStream(client, subscription.ID, &StreamOptions{BatchLimit: 2})
+	streamAPI := NewStream(client, subscription.ID, &StreamOptions{BatchLimit: 2, CommitRetry: true})
 	received := []DataChangeEvent{}
 	for len(received) < len(events) {
 		cursor, rawEvents, err := streamAPI.NextEvents()


### PR DESCRIPTION
Retry commit is now optional.
fixes #6 