### PR TITLE
Create a fresh BackOff for every request

### DIFF
--- a/events.go
+++ b/events.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
 )
 
@@ -90,31 +89,25 @@ func (o *EventOptions) withDefaults() *EventOptions {
 func NewEventAPI(client *Client, options *EventOptions) *EventAPI {
 	options = options.withDefaults()
 
-	var backOff backoff.BackOff
-	if options.Retry {
-		back := backoff.NewExponentialBackOff()
-		back.InitialInterval = options.InitialRetryInterval
-		back.MaxInterval = options.MaxRetryInterval
-		back.MaxElapsedTime = options.MaxElapsedTime
-		backOff = back
-	} else {
-		backOff = &backoff.StopBackOff{}
-	}
 	return &EventAPI{
-		client:  client,
-		backOff: backOff}
+		client: client,
+		backOffConf: backOffConfiguration{
+			Retry:                options.Retry,
+			InitialRetryInterval: options.InitialRetryInterval,
+			MaxRetryInterval:     options.MaxRetryInterval,
+			MaxElapsedTime:       options.MaxElapsedTime}}
 }
 
 // EventAPI is a sub API that allows to inspect and manage event types on a Nakadi instance.
 type EventAPI struct {
-	client  *Client
-	backOff backoff.BackOff
+	client      *Client
+	backOffConf backOffConfiguration
 }
 
 // List returns all registered event types.
 func (e *EventAPI) List() ([]*EventType, error) {
 	eventTypes := []*EventType{}
-	err := e.client.httpGET(e.backOff, e.eventBaseURL(), &eventTypes, "unable to request event types")
+	err := e.client.httpGET(e.backOffConf.createBackOff(), e.eventBaseURL(), &eventTypes, "unable to request event types")
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +117,7 @@ func (e *EventAPI) List() ([]*EventType, error) {
 // Get returns an event type based on its name.
 func (e *EventAPI) Get(name string) (*EventType, error) {
 	eventType := &EventType{}
-	err := e.client.httpGET(e.backOff, e.eventURL(name), eventType, "unable to request event types")
+	err := e.client.httpGET(e.backOffConf.createBackOff(), e.eventURL(name), eventType, "unable to request event types")
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +126,7 @@ func (e *EventAPI) Get(name string) (*EventType, error) {
 
 // Create saves a new event type.
 func (e *EventAPI) Create(eventType *EventType) error {
-	response, err := e.client.httpPOST(e.backOff, e.eventBaseURL(), eventType)
+	response, err := e.client.httpPOST(e.backOffConf.createBackOff(), e.eventBaseURL(), eventType)
 	if err != nil {
 		return errors.Wrap(err, "unable to create event type")
 	}
@@ -152,7 +145,7 @@ func (e *EventAPI) Create(eventType *EventType) error {
 
 // Update updates an existing event type.
 func (e *EventAPI) Update(eventType *EventType) error {
-	response, err := e.client.httpPUT(e.backOff, e.eventURL(eventType.Name), eventType)
+	response, err := e.client.httpPUT(e.backOffConf.createBackOff(), e.eventURL(eventType.Name), eventType)
 	if err != nil {
 		return errors.Wrap(err, "unable to update event type")
 	}
@@ -171,7 +164,7 @@ func (e *EventAPI) Update(eventType *EventType) error {
 
 // Delete removes an event type.
 func (e *EventAPI) Delete(name string) error {
-	return e.client.httpDELETE(e.backOff, e.eventURL(name), "unable to delete event type")
+	return e.client.httpDELETE(e.backOffConf.createBackOff(), e.eventURL(name), "unable to delete event type")
 }
 
 func (e *EventAPI) eventURL(name string) string {

--- a/events.go
+++ b/events.go
@@ -107,7 +107,7 @@ type EventAPI struct {
 // List returns all registered event types.
 func (e *EventAPI) List() ([]*EventType, error) {
 	eventTypes := []*EventType{}
-	err := e.client.httpGET(e.backOffConf.createBackOff(), e.eventBaseURL(), &eventTypes, "unable to request event types")
+	err := e.client.httpGET(e.backOffConf.create(), e.eventBaseURL(), &eventTypes, "unable to request event types")
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (e *EventAPI) List() ([]*EventType, error) {
 // Get returns an event type based on its name.
 func (e *EventAPI) Get(name string) (*EventType, error) {
 	eventType := &EventType{}
-	err := e.client.httpGET(e.backOffConf.createBackOff(), e.eventURL(name), eventType, "unable to request event types")
+	err := e.client.httpGET(e.backOffConf.create(), e.eventURL(name), eventType, "unable to request event types")
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (e *EventAPI) Get(name string) (*EventType, error) {
 
 // Create saves a new event type.
 func (e *EventAPI) Create(eventType *EventType) error {
-	response, err := e.client.httpPOST(e.backOffConf.createBackOff(), e.eventBaseURL(), eventType)
+	response, err := e.client.httpPOST(e.backOffConf.create(), e.eventBaseURL(), eventType)
 	if err != nil {
 		return errors.Wrap(err, "unable to create event type")
 	}
@@ -145,7 +145,7 @@ func (e *EventAPI) Create(eventType *EventType) error {
 
 // Update updates an existing event type.
 func (e *EventAPI) Update(eventType *EventType) error {
-	response, err := e.client.httpPUT(e.backOffConf.createBackOff(), e.eventURL(eventType.Name), eventType)
+	response, err := e.client.httpPUT(e.backOffConf.create(), e.eventURL(eventType.Name), eventType)
 	if err != nil {
 		return errors.Wrap(err, "unable to update event type")
 	}
@@ -164,7 +164,7 @@ func (e *EventAPI) Update(eventType *EventType) error {
 
 // Delete removes an event type.
 func (e *EventAPI) Delete(name string) error {
-	return e.client.httpDELETE(e.backOffConf.createBackOff(), e.eventURL(name), "unable to delete event type")
+	return e.client.httpDELETE(e.backOffConf.create(), e.eventURL(name), "unable to delete event type")
 }
 
 func (e *EventAPI) eventURL(name string) string {

--- a/helper.go
+++ b/helper.go
@@ -78,8 +78,8 @@ type backOffConfiguration struct {
 	MaxElapsedTime time.Duration
 }
 
-// createBackOff initializes a new backoff from configured parameters.
-func (rc *backOffConfiguration) createBackOff() backoff.BackOff {
+// create initializes a new backoff from configured parameters.
+func (rc *backOffConfiguration) create() backoff.BackOff {
 	if !rc.Retry {
 		return &backoff.StopBackOff{}
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -55,7 +55,7 @@ func TestBackOffConfiguration_createBackOff(t *testing.T) {
 			MaxRetryInterval:     1 * time.Second,
 			MaxElapsedTime:       1 * time.Minute}
 
-		backOff := backOffConf.createBackOff()
+		backOff := backOffConf.create()
 		assert.IsType(t, &backoff.StopBackOff{}, backOff)
 	})
 
@@ -66,7 +66,7 @@ func TestBackOffConfiguration_createBackOff(t *testing.T) {
 			MaxRetryInterval:     1 * time.Second,
 			MaxElapsedTime:       1 * time.Minute}
 
-		backOff := backOffConf.createBackOff()
+		backOff := backOffConf.create()
 		require.IsType(t, &backoff.ExponentialBackOff{}, backOff)
 
 		expBackOff := backOff.(*backoff.ExponentialBackOff)

--- a/helper_test.go
+++ b/helper_test.go
@@ -99,7 +99,7 @@ func helperMakeCounter(n int) chan int {
 }
 
 // brokenBodyReader is an implementation of ReadCloser interface to be used for
-// mocking errors while reaing from body
+// mocking errors while reading from body
 type brokenBodyReader struct{}
 
 func (brokenBodyReader) Read(p []byte) (n int, err error) { return 0, assert.AnError }

--- a/publish.go
+++ b/publish.go
@@ -119,7 +119,7 @@ func (p *PublishAPI) PublishBusinessEvent(events []BusinessEvent) error {
 // business events. Depending on the options used when creating the PublishAPI this method will retry
 // to publish the events if the were not successfully published.
 func (p *PublishAPI) Publish(events interface{}) error {
-	response, err := p.client.httpPOST(p.backOffConf.createBackOff(), p.publishURL, events)
+	response, err := p.client.httpPOST(p.backOffConf.create(), p.publishURL, events)
 	if err != nil {
 		return errors.Wrap(err, "unable to publish event")
 	}

--- a/streams.go
+++ b/streams.go
@@ -135,7 +135,7 @@ func (s *StreamAPI) NextEvents() (Cursor, []byte, error) {
 func (s *StreamAPI) CommitCursor(cursor Cursor) error {
 	var err error
 
-	commitBackOff := backoff.WithContext(s.commitBackOffConf.createBackOff(), s.ctx)
+	commitBackOff := backoff.WithContext(s.commitBackOffConf.create(), s.ctx)
 	backoff.RetryNotify(func() error {
 		err = s.committer.commitCursor(cursor)
 		return err
@@ -161,7 +161,7 @@ func (s *StreamAPI) startStream() {
 		var err error
 		var stream streamer
 
-		streamBackOff := backoff.WithContext(s.streamBackOffConf.createBackOff(), s.ctx)
+		streamBackOff := backoff.WithContext(s.streamBackOffConf.create(), s.ctx)
 		backoff.RetryNotify(func() error {
 			stream, err = s.opener.openStream()
 			return err

--- a/streams.go
+++ b/streams.go
@@ -75,20 +75,6 @@ func NewStream(client *Client, subscriptionID string, options *StreamOptions) *S
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	streamBackOff := backoff.NewExponentialBackOff()
-	streamBackOff.InitialInterval = options.InitialRetryInterval
-	streamBackOff.MaxInterval = options.MaxRetryInterval
-
-	var commitBackOff backoff.BackOff
-	if options.CommitRetry {
-		back := backoff.NewExponentialBackOff()
-		back.InitialInterval = options.InitialRetryInterval
-		back.MaxInterval = options.MaxRetryInterval
-		commitBackOff = back
-	} else {
-		commitBackOff = &backoff.StopBackOff{}
-	}
-
 	streamAPI := &StreamAPI{
 		opener: &simpleStreamOpener{
 			client:         client,
@@ -97,13 +83,22 @@ func NewStream(client *Client, subscriptionID string, options *StreamOptions) *S
 		committer: &simpleCommitter{
 			client:         client,
 			subscriptionID: subscriptionID},
-		eventCh:       make(chan eventsOrError, 10),
-		ctx:           ctx,
-		cancel:        cancel,
-		streamBackOff: backoff.WithContext(streamBackOff, ctx),
-		commitBackOff: backoff.WithContext(commitBackOff, ctx),
-		notifyErr:     options.NotifyErr,
-		notifyOK:      options.NotifyOK}
+		eventCh: make(chan eventsOrError, 10),
+		ctx:     ctx,
+		cancel:  cancel,
+		streamBackOffConf: backOffConfiguration{
+			Retry:                true,
+			InitialRetryInterval: options.InitialRetryInterval,
+			MaxRetryInterval:     options.MaxRetryInterval,
+		},
+		commitBackOffConf: backOffConfiguration{
+			Retry:                options.CommitRetry,
+			InitialRetryInterval: options.InitialRetryInterval,
+			MaxRetryInterval:     options.MaxRetryInterval,
+			MaxElapsedTime:       options.CommitMaxElapsedTime,
+		},
+		notifyErr: options.NotifyErr,
+		notifyOK:  options.NotifyOK}
 
 	go streamAPI.startStream()
 
@@ -114,15 +109,15 @@ func NewStream(client *Client, subscriptionID string, options *StreamOptions) *S
 // high level stream API. In order to ensure that only successfully processed events are committed, it is
 // crucial to commit cursors of respective event batches in the same order they were received.
 type StreamAPI struct {
-	opener        streamOpener
-	committer     committer
-	eventCh       chan eventsOrError
-	ctx           context.Context
-	cancel        context.CancelFunc
-	commitBackOff backoff.BackOff
-	streamBackOff backoff.BackOff
-	notifyErr     func(error, time.Duration)
-	notifyOK      func()
+	opener            streamOpener
+	committer         committer
+	eventCh           chan eventsOrError
+	ctx               context.Context
+	cancel            context.CancelFunc
+	commitBackOffConf backOffConfiguration
+	streamBackOffConf backOffConfiguration
+	notifyErr         func(error, time.Duration)
+	notifyOK          func()
 }
 
 // NextEvents reads the next batch of events from the stream and returns the encoded events along with the
@@ -140,10 +135,11 @@ func (s *StreamAPI) NextEvents() (Cursor, []byte, error) {
 func (s *StreamAPI) CommitCursor(cursor Cursor) error {
 	var err error
 
+	commitBackOff := backoff.WithContext(s.commitBackOffConf.createBackOff(), s.ctx)
 	backoff.RetryNotify(func() error {
 		err = s.committer.commitCursor(cursor)
 		return err
-	}, s.commitBackOff, s.notifyErr)
+	}, commitBackOff, s.notifyErr)
 
 	if err == nil {
 		s.notifyOK()
@@ -165,10 +161,11 @@ func (s *StreamAPI) startStream() {
 		var err error
 		var stream streamer
 
+		streamBackOff := backoff.WithContext(s.streamBackOffConf.createBackOff(), s.ctx)
 		backoff.RetryNotify(func() error {
 			stream, err = s.opener.openStream()
 			return err
-		}, s.streamBackOff, s.notifyErr)
+		}, streamBackOff, s.notifyErr)
 
 		if err != nil {
 			continue

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -81,7 +81,7 @@ func (s *SubscriptionAPI) List() ([]*Subscription, error) {
 	subscriptions := struct {
 		Items []*Subscription `json:"items"`
 	}{}
-	err := s.client.httpGET(s.backOffConf.createBackOff(), s.subBaseURL(), &subscriptions, "unable to request subscriptions")
+	err := s.client.httpGET(s.backOffConf.create(), s.subBaseURL(), &subscriptions, "unable to request subscriptions")
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (s *SubscriptionAPI) List() ([]*Subscription, error) {
 // Get obtains a single subscription identified by its ID.
 func (s *SubscriptionAPI) Get(id string) (*Subscription, error) {
 	subscription := &Subscription{}
-	err := s.client.httpGET(s.backOffConf.createBackOff(), s.subURL(id), subscription, "unable to request subscription")
+	err := s.client.httpGET(s.backOffConf.create(), s.subURL(id), subscription, "unable to request subscription")
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (s *SubscriptionAPI) Get(id string) (*Subscription, error) {
 // Create initializes a new subscription. If the subscription already exists the pre existing subscription
 // is returned.
 func (s *SubscriptionAPI) Create(subscription *Subscription) (*Subscription, error) {
-	response, err := s.client.httpPOST(s.backOffConf.createBackOff(), s.subBaseURL(), subscription)
+	response, err := s.client.httpPOST(s.backOffConf.create(), s.subBaseURL(), subscription)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create subscription")
 	}
@@ -126,7 +126,7 @@ func (s *SubscriptionAPI) Create(subscription *Subscription) (*Subscription, err
 
 // Delete removes an existing subscription.
 func (s *SubscriptionAPI) Delete(id string) error {
-	return s.client.httpDELETE(s.backOffConf.createBackOff(), s.subURL(id), "unable to delete subscription")
+	return s.client.httpDELETE(s.backOffConf.create(), s.subURL(id), "unable to delete subscription")
 }
 
 // SubscriptionStats represents detailed statistics for the subscription
@@ -150,7 +150,7 @@ type statsResponse struct {
 // GetStats returns statistic information for subscription
 func (s *SubscriptionAPI) GetStats(id string) ([]*SubscriptionStats, error) {
 	stats := &statsResponse{}
-	if err := s.client.httpGET(s.backOffConf.createBackOff(), s.subURL(id)+"/stats", stats, "unable to get stats for subscription"); err != nil {
+	if err := s.client.httpGET(s.backOffConf.create(), s.subURL(id)+"/stats", stats, "unable to get stats for subscription"); err != nil {
 		return nil, err
 	}
 	return stats.Items, nil

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -135,7 +135,7 @@ type SubscriptionStats struct {
 	Partitions []*PartitionStats `json:"partitions"`
 }
 
-// PartitionStats represents statistic information for the particular partiion
+// PartitionStats represents statistic information for the particular partition
 type PartitionStats struct {
 	Partition        string `json:"partition"`
 	State            string `json:"state"`


### PR DESCRIPTION
In order to avoid concurrent access to `BackOff` instances a new `BackOff` is created for every request.

fixes #12