### PR TITLE
Issue-14: fix racy tests and enable race detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
 script:
 - go vet -v
 - golint -set_exit_status .
-- go test -v -tags=integration -covermode=count -coverprofile=profile.cov .
+- go test -v -tags=integration -race -covermode=count -coverprofile=profile.cov .
 
 after_script:
 - (cd nakadi && ./gradlew stopNakadi)

--- a/processor_test.go
+++ b/processor_test.go
@@ -121,7 +121,7 @@ func TestNewProcessor(t *testing.T) {
 	assert.Equal(t, client, processor.client)
 	assert.Equal(t, testSubscriptionID, processor.subscriptionID)
 	assert.Len(t, processor.streamOptions, 1)
-	assert.Len(t, processor.streams, 0)
+	assert.False(t, processor.isStarted)
 	assert.Equal(t, 10*time.Second, processor.timePerBatchPerStream)
 	assert.NotNil(t, processor.ctx)
 	assert.NotNil(t, processor.cancel)
@@ -129,8 +129,8 @@ func TestNewProcessor(t *testing.T) {
 
 func TestProcessor_Start(t *testing.T) {
 	t.Run("fail running stream", func(t *testing.T) {
-		_, s, processor := setupMockProcessor()
-		processor.streams = []streamAPI{s}
+		_, _, processor := setupMockProcessor()
+		processor.isStarted = true
 
 		err := processor.Start(func(i int, id string, batch []byte) error { return nil })
 		require.Error(t, err)
@@ -301,7 +301,8 @@ func setupMockProcessor() (*mockNewStream, *mockStreamAPI, *Processor) {
 		cancel:                cancel,
 		newStream:             mockNewStream.NewStream,
 		timePerBatchPerStream: 100 * time.Millisecond,
-		streamOptions:         []StreamOptions{*testStreamOptions}}
+		streamOptions:         []StreamOptions{*testStreamOptions},
+		closeErrorCh:          make(chan error)}
 
 	return mockNewStream, mockStreamAPI, processor
 }

--- a/streams_test.go
+++ b/streams_test.go
@@ -189,7 +189,7 @@ func TestStreamAPI_Close(t *testing.T) {
 	}()
 
 	blockCh <- time.Now()
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	blockCh <- time.Now()
 
 	err := <-errorCh


### PR DESCRIPTION
Some refactoring in `StreamAPI` that was causing a false positive when `-race` was used in tests.

fixes #14 