### PR TITLE
Remove race condition in processor sub API

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -104,7 +104,8 @@ func NewProcessor(client *Client, subscriptionID string, options *ProcessorOptio
 		newStream: func(client *Client, id string, options *StreamOptions) streamAPI {
 			return NewStream(client, id, options)
 		},
-		timePerBatchPerStream: time.Duration(timePerBatchPerStream)}
+		timePerBatchPerStream: time.Duration(timePerBatchPerStream),
+		closeErrorCh:          make(chan error)}
 
 	for i := uint(0); i < options.StreamCount; i++ {
 		streamOptions := StreamOptions{
@@ -133,9 +134,10 @@ type Processor struct {
 	streamOptions         []StreamOptions
 	newStream             func(*Client, string, *StreamOptions) streamAPI
 	timePerBatchPerStream time.Duration
-	streams               []streamAPI
+	isStarted             bool
 	ctx                   context.Context
 	cancel                context.CancelFunc
+	closeErrorCh          chan error
 }
 
 // Operation defines a certain procedure that consumes the event data from a processor. An operation,
@@ -155,11 +157,10 @@ func (p *Processor) Start(operation Operation) error {
 	p.Lock()
 	defer p.Unlock()
 
-	if len(p.streams) > 0 {
+	if p.isStarted {
 		return errors.New("processor was already started")
 	}
-
-	p.streams = make([]streamAPI, len(p.streamOptions))
+	p.isStarted = true
 
 	for streamNo, options := range p.streamOptions {
 		go p.startSingleStream(operation, streamNo, options)
@@ -171,12 +172,13 @@ func (p *Processor) Start(operation Operation) error {
 // startSingleStream starts a single stream with a given stream number / position. After the stream has been
 // started it consumes events. In cases of errors the stream is closed and a new stream will be opened.
 func (p *Processor) startSingleStream(operation Operation, streamNo int, options StreamOptions) {
-	p.streams[streamNo] = p.newStream(p.client, p.subscriptionID, &options)
+	stream := p.newStream(p.client, p.subscriptionID, &options)
 
 	if p.timePerBatchPerStream > 0 {
 		initialWait := rand.Int63n(int64(p.timePerBatchPerStream))
 		select {
 		case <-p.ctx.Done():
+			p.closeErrorCh <- stream.Close()
 			return
 		case <-time.After(time.Duration(initialWait)):
 			// nothing
@@ -188,29 +190,32 @@ func (p *Processor) startSingleStream(operation Operation, streamNo int, options
 
 		select {
 		case <-p.ctx.Done():
+			p.closeErrorCh <- stream.Close()
 			return
 		default:
-			cursor, events, err := p.streams[streamNo].NextEvents()
+			cursor, events, err := stream.NextEvents()
 			if err != nil {
 				continue
 			}
 
 			err = operation(streamNo, cursor.NakadiStreamID, events)
 			if err != nil {
-				p.Lock()
-				p.streams[streamNo].Close()
-				p.streams[streamNo] = p.newStream(p.client, p.subscriptionID, &options)
-				p.Unlock()
+				err = stream.Close()
+				if err != nil {
+					options.NotifyErr(err, 0)
+				}
+				stream = p.newStream(p.client, p.subscriptionID, &options)
 				continue
 			}
 
-			p.streams[streamNo].CommitCursor(cursor)
+			stream.CommitCursor(cursor)
 		}
 
 		elapsed := time.Since(start)
 		if elapsed < p.timePerBatchPerStream {
 			select {
 			case <-p.ctx.Done():
+				p.closeErrorCh <- stream.Close()
 				return
 			case <-time.After(p.timePerBatchPerStream - elapsed):
 				// nothing
@@ -225,24 +230,21 @@ func (p *Processor) Stop() error {
 	p.Lock()
 	defer p.Unlock()
 
-	if len(p.streams) == 0 {
+	if !p.isStarted {
 		return errors.New("processor is not running")
 	}
 
 	p.cancel()
 
-	var allErrors []error
-	for _, s := range p.streams {
-		err := s.Close()
+	var errCount int
+	for i := 0; i < len(p.streamOptions); i++ {
+		err := <-p.closeErrorCh
 		if err != nil {
-			allErrors = append(allErrors, err)
+			errCount++
 		}
 	}
-
-	p.streams = nil
-
-	if len(allErrors) > 0 {
-		return errors.Errorf("%d streams had errors while closing the stream", len(allErrors))
+	if errCount > 0 {
+		return errors.Errorf("%d streams had errors while closing the stream", errCount)
 	}
 
 	return nil

--- a/processor_test.go
+++ b/processor_test.go
@@ -121,7 +121,7 @@ func TestNewProcessor(t *testing.T) {
 	assert.Equal(t, client, processor.client)
 	assert.Equal(t, testSubscriptionID, processor.subscriptionID)
 	assert.Len(t, processor.streamOptions, 1)
-	assert.Len(t, processor.streams, 0)
+	assert.False(t, processor.isStarted)
 	assert.Equal(t, 10*time.Second, processor.timePerBatchPerStream)
 	assert.NotNil(t, processor.ctx)
 	assert.NotNil(t, processor.cancel)
@@ -129,8 +129,8 @@ func TestNewProcessor(t *testing.T) {
 
 func TestProcessor_Start(t *testing.T) {
 	t.Run("fail running stream", func(t *testing.T) {
-		_, s, processor := setupMockProcessor()
-		processor.streams = []streamAPI{s}
+		_, _, processor := setupMockProcessor()
+		processor.isStarted = true
 
 		err := processor.Start(func(i int, id string, batch []byte) error { return nil })
 		require.Error(t, err)
@@ -301,7 +301,8 @@ func setupMockProcessor() (*mockNewStream, *mockStreamAPI, *Processor) {
 		cancel:                cancel,
 		newStream:             mockNewStream.NewStream,
 		timePerBatchPerStream: 100 * time.Millisecond,
-		streamOptions:         []StreamOptions{*testStreamOptions}}
+		streamOptions:         []StreamOptions{*testStreamOptions},
+		closeErrorCh:          make(chan error)}
 
 	return mockNewStream, mockStreamAPI, processor
 }

--- a/streams_test.go
+++ b/streams_test.go
@@ -189,7 +189,7 @@ func TestStreamAPI_Close(t *testing.T) {
 	}()
 
 	blockCh <- time.Now()
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	blockCh <- time.Now()
 
 	err := <-errorCh


### PR DESCRIPTION
This change removes a detected race condition in the processor sub API. This is just a step towards #14, there are still some potential racy parts in the stream API. Those changes are not in the scope of this PR.