### PR TITLE
Add missing subscribtion parameters

### DIFF
--- a/nakadi_example_test.go
+++ b/nakadi_example_test.go
@@ -10,7 +10,7 @@ import (
 
 func Example_complete() {
 	//  create a new client
-	client := nakadi.New("http://localhost:8080", &nakadi.ClientOptions{ConnectionTimeout: 500 * time.Millisecond})
+	client := nakadi.New("http://localhost:8080", &nakadi.ClientOptions{ConnectionTimeout: 2000 * time.Millisecond})
 
 	// create an event api create a new event type
 	eventAPI := nakadi.NewEventAPI(client, &nakadi.EventOptions{Retry: true})

--- a/nakadi_example_test.go
+++ b/nakadi_example_test.go
@@ -10,7 +10,7 @@ import (
 
 func Example_complete() {
 	//  create a new client
-	client := nakadi.New("http://localhost:8080", &nakadi.ClientOptions{ConnectionTimeout: 2000 * time.Millisecond})
+	client := nakadi.New("http://localhost:8080", &nakadi.ClientOptions{ConnectionTimeout: 500 * time.Millisecond})
 
 	// create an event api create a new event type
 	eventAPI := nakadi.NewEventAPI(client, &nakadi.EventOptions{Retry: true})

--- a/processor.go
+++ b/processor.go
@@ -22,6 +22,9 @@ type ProcessorOptions struct {
 	// or the actual batch size is lower than BatchLimit the actual number of processed events can be
 	// much lower. 0 is interpreted as no limit at all (default: no limit)
 	EventsPerMinute uint
+	//  The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
+	//  state and commit comes - the stream will resume (default: 10)
+	MaxUncommittedEvents uint
 	// The initial (minimal) retry interval used for the exponential backoff. This value is applied for
 	// stream initialization as well as for cursor commits.
 	InitialRetryInterval time.Duration
@@ -73,6 +76,9 @@ func (o *ProcessorOptions) withDefaults() *ProcessorOptions {
 	if copyOptions.NotifyOK == nil {
 		copyOptions.NotifyOK = func(_ uint) {}
 	}
+	if copyOptions.MaxUncommittedEvents == 0 {
+		copyOptions.MaxUncommittedEvents = 10
+	}
 	return &copyOptions
 }
 
@@ -111,6 +117,7 @@ func NewProcessor(client *Client, subscriptionID string, options *ProcessorOptio
 		streamOptions := StreamOptions{
 			BatchLimit:           options.BatchLimit,
 			FlushTimeout:         options.FlushTimeout,
+			MaxUncommittedEvents: options.MaxUncommittedEvents,
 			InitialRetryInterval: options.InitialRetryInterval,
 			MaxRetryInterval:     options.MaxRetryInterval,
 			CommitMaxElapsedTime: options.CommitMaxElapsedTime,

--- a/processor.go
+++ b/processor.go
@@ -22,8 +22,9 @@ type ProcessorOptions struct {
 	// or the actual batch size is lower than BatchLimit the actual number of processed events can be
 	// much lower. 0 is interpreted as no limit at all (default: no limit)
 	EventsPerMinute uint
-	//  The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
-	//  state and commit comes - the stream will resume (default: 10)
+	// The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
+	// state and commit comes - the stream will resume. If MaxUncommittedEvents is lower than BatchLimit,
+	// effective batch size will be upperbound by MaxUncommittedEvents. (default: 10)
 	MaxUncommittedEvents uint
 	// The initial (minimal) retry interval used for the exponential backoff. This value is applied for
 	// stream initialization as well as for cursor commits.

--- a/processor.go
+++ b/processor.go
@@ -24,7 +24,7 @@ type ProcessorOptions struct {
 	EventsPerMinute uint
 	// The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
 	// state and commit comes - the stream will resume. If MaxUncommittedEvents is lower than BatchLimit,
-	// effective batch size will be upperbound by MaxUncommittedEvents. (default: 10)
+	// effective batch size will be upperbound by MaxUncommittedEvents. (default: 10, minimum: 1)
 	MaxUncommittedEvents uint
 	// The initial (minimal) retry interval used for the exponential backoff. This value is applied for
 	// stream initialization as well as for cursor commits.

--- a/processor_test.go
+++ b/processor_test.go
@@ -30,6 +30,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: defaultInitialRetryInterval,
 				MaxRetryInterval:     defaultMaxRetryInterval,
 				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 10,
 			},
 		},
 		{
@@ -41,6 +42,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: defaultInitialRetryInterval,
 				MaxRetryInterval:     defaultMaxRetryInterval,
 				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 10,
 			},
 		},
 		{
@@ -52,6 +54,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: defaultInitialRetryInterval,
 				MaxRetryInterval:     defaultMaxRetryInterval,
 				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 10,
 			},
 		},
 		{
@@ -63,6 +66,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: defaultInitialRetryInterval,
 				MaxRetryInterval:     defaultMaxRetryInterval,
 				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 10,
 			},
 		},
 		{
@@ -74,6 +78,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: 123 * time.Millisecond,
 				MaxRetryInterval:     defaultMaxRetryInterval,
 				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 10,
 			},
 		},
 		{
@@ -85,6 +90,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: defaultInitialRetryInterval,
 				MaxRetryInterval:     123 * time.Second,
 				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 10,
 			},
 		},
 		{
@@ -96,6 +102,19 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 				InitialRetryInterval: defaultInitialRetryInterval,
 				MaxRetryInterval:     defaultMaxRetryInterval,
 				CommitMaxElapsedTime: 123 * time.Second,
+				MaxUncommittedEvents: 10,
+			},
+		},
+		{
+			Options: &ProcessorOptions{MaxUncommittedEvents: 15},
+			Expected: &ProcessorOptions{
+				BatchLimit:           1,
+				StreamCount:          1,
+				EventsPerMinute:      0,
+				InitialRetryInterval: defaultInitialRetryInterval,
+				MaxRetryInterval:     defaultMaxRetryInterval,
+				CommitMaxElapsedTime: defaultMaxElapsedTime,
+				MaxUncommittedEvents: 15,
 			},
 		},
 	}
@@ -108,6 +127,7 @@ func TestProcessorOptions_withDefaults(t *testing.T) {
 		assert.Equal(t, tt.Expected.InitialRetryInterval, withDefaults.InitialRetryInterval)
 		assert.Equal(t, tt.Expected.MaxRetryInterval, withDefaults.MaxRetryInterval)
 		assert.Equal(t, tt.Expected.CommitMaxElapsedTime, withDefaults.CommitMaxElapsedTime)
+		assert.Equal(t, tt.Expected.MaxUncommittedEvents, withDefaults.MaxUncommittedEvents)
 		assert.NotNil(t, withDefaults.NotifyErr)
 		assert.NotNil(t, withDefaults.NotifyOK)
 	}

--- a/simple_stream.go
+++ b/simple_stream.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	"strconv"
 )
 
 // simpleStreamOpener implements the streamOpener interface.
@@ -60,13 +61,14 @@ func (so *simpleStreamOpener) openStream() (streamer, error) {
 func (so *simpleStreamOpener) streamURL(id string) string {
 	queryParams := url.Values{}
 	if so.batchLimit > 0 {
-		queryParams.Add("batch_limit", fmt.Sprint(so.batchLimit))
+
+		queryParams.Add("batch_limit", strconv.FormatUint(uint64(so.batchLimit), 10))
 	}
 	if so.flushTimeout > 0 {
-		queryParams.Add("batch_flush_timeout", fmt.Sprint(so.flushTimeout))
+		queryParams.Add("batch_flush_timeout", strconv.FormatUint(uint64(so.flushTimeout), 10))
 	}
 	if so.maxUncommittedEvents > 0 {
-		queryParams.Add("max_uncommitted_events", fmt.Sprint(so.maxUncommittedEvents))
+		queryParams.Add("max_uncommitted_events", strconv.FormatUint(uint64(so.maxUncommittedEvents), 10))
 	}
 
 	return fmt.Sprintf("%s/subscriptions/%s/events?%s", so.client.nakadiURL, id, queryParams.Encode())

--- a/streams.go
+++ b/streams.go
@@ -25,7 +25,7 @@ type StreamOptions struct {
 	FlushTimeout uint
 	// The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
 	// state and commit comes - the stream will resume. If MaxUncommittedEvents is lower than BatchLimit,
-	// effective batch size will be upperbound by MaxUncommittedEvents. (default: 10)
+	// effective batch size will be upperbound by MaxUncommittedEvents. (default: 10, minimum: 1)
 	MaxUncommittedEvents uint
 	// The initial (minimal) retry interval used for the exponential backoff. This value is applied for
 	// stream initialization as well as for cursor commits.

--- a/streams.go
+++ b/streams.go
@@ -23,8 +23,9 @@ type StreamOptions struct {
 	BatchLimit uint
 	// Maximum time in seconds to wait for the flushing of each chunk (per partition).(default: 30)
 	FlushTimeout uint
-	//  The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
-	//  state and commit comes - the stream will resume (default: 10)
+	// The amount of uncommitted events Nakadi will stream before pausing the stream. When in paused
+	// state and commit comes - the stream will resume. If MaxUncommittedEvents is lower than BatchLimit,
+	// effective batch size will be upperbound by MaxUncommittedEvents. (default: 10)
 	MaxUncommittedEvents uint
 	// The initial (minimal) retry interval used for the exponential backoff. This value is applied for
 	// stream initialization as well as for cursor commits.

--- a/streams_integration_test.go
+++ b/streams_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegrationStreamAPI(t *testing.T) {
 	}
 
 	// stream events
-	streamAPI := NewStream(client, subscription.ID, &StreamOptions{BatchLimit: 2, CommitRetry: true})
+	streamAPI := NewStream(client, subscription.ID, &StreamOptions{BatchLimit: 4, MaxUncommittedEvents: 2, CommitRetry: true})
 	received := []DataChangeEvent{}
 	for len(received) < len(events) {
 		cursor, rawEvents, err := streamAPI.NextEvents()


### PR DESCRIPTION
Implements #32

Allows setting  `max_uncommited_events` for nakadi stream, through `ProcessorOptions`.
