### PR TITLE
Do not reuse requests instances on retries

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,11 @@
+{
+  "Disable": [
+    "errcheck",
+    "gotypex",
+    "gocyclo"
+  ],
+  "Exclude": [
+    "Errors unhandled.,LOW,HIGH \\(gas\\)",
+    "declaration of \"err\" shadows declaration"
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_install:
 install:
 - git clone https://github.com/zalando/nakadi.git nakadi
 - go get -v github.com/pkg/errors
-- go get -v github.com/golang/lint/golint
+- go get -v -u github.com/alecthomas/gometalinter
+- gometalinter --install
 - go get -v github.com/mattn/goveralls
 - go get -v github.com/stretchr/testify/...
 - go get -v github.com/cenkalti/backoff
@@ -48,8 +49,7 @@ before_script:
 - (cd nakadi && ./gradlew startNakadi)
 
 script:
-- go vet -v
-- golint -set_exit_status .
+- gometalinter --config=.gometalinter.json --deadline=10m .
 - go test -v -tags=integration -covermode=count -coverprofile=profile.cov .
 
 after_script:

--- a/nakadi.go
+++ b/nakadi.go
@@ -78,21 +78,21 @@ func New(url string, options *ClientOptions) *Client {
 
 // httpGET fetches json encoded data with a GET request.
 func (c *Client) httpGET(backOff backoff.BackOff, url string, body interface{}, msg string) error {
-	request, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return errors.Wrapf(err, "%s: unable to prepare request", msg)
-	}
-
-	if c.tokenProvider != nil {
-		token, err := c.tokenProvider()
-		if err != nil {
-			return errors.Wrapf(err, "%s: unable to prepare request", msg)
-		}
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
-
 	var response *http.Response
-	err = backoff.Retry(func() error {
+	err := backoff.Retry(func() error {
+		request, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+		}
+
+		if c.tokenProvider != nil {
+			token, err := c.tokenProvider()
+			if err != nil {
+				return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+			}
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		response, err = c.httpClient.Do(request)
 		if err != nil {
 			return errors.Wrap(err, msg)
@@ -139,22 +139,22 @@ func (c *Client) httpPUT(backOff backoff.BackOff, url string, body interface{}, 
 		return nil, errors.Wrapf(err, "%s: unable to encode json body", msg)
 	}
 
-	request, err := http.NewRequest("PUT", url, bytes.NewReader(encoded))
-	if err != nil {
-		return nil, errors.Wrapf(err, "%s: unable to prepare request", msg)
-	}
-
-	request.Header.Set("Content-Type", "application/json;charset=UTF-8")
-	if c.tokenProvider != nil {
-		token, err := c.tokenProvider()
-		if err != nil {
-			return nil, errors.Wrapf(err, "%s: unable to prepare request", msg)
-		}
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
-
 	var response *http.Response
 	err = backoff.Retry(func() error {
+		request, err := http.NewRequest("PUT", url, bytes.NewReader(encoded))
+		if err != nil {
+			return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+		}
+
+		request.Header.Set("Content-Type", "application/json;charset=UTF-8")
+		if c.tokenProvider != nil {
+			token, err := c.tokenProvider()
+			if err != nil {
+				return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+			}
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		response, err = c.httpClient.Do(request)
 		if err != nil {
 			return errors.Wrap(err, msg)
@@ -183,22 +183,22 @@ func (c *Client) httpPOST(backOff backoff.BackOff, url string, body interface{},
 		return nil, errors.Wrapf(err, "%s: unable to encode json body", msg)
 	}
 
-	request, err := http.NewRequest("POST", url, bytes.NewReader(encoded))
-	if err != nil {
-		return nil, errors.Wrapf(err, "%s: unable to prepare request", msg)
-	}
-
-	request.Header.Set("Content-Type", "application/json;charset=UTF-8")
-	if c.tokenProvider != nil {
-		token, err := c.tokenProvider()
-		if err != nil {
-			return nil, errors.Wrapf(err, "%s: unable to prepare request", msg)
-		}
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
-
 	var response *http.Response
 	err = backoff.Retry(func() error {
+		request, err := http.NewRequest("POST", url, bytes.NewReader(encoded))
+		if err != nil {
+			return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+		}
+
+		request.Header.Set("Content-Type", "application/json;charset=UTF-8")
+		if c.tokenProvider != nil {
+			token, err := c.tokenProvider()
+			if err != nil {
+				return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+			}
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		response, err = c.httpClient.Do(request)
 		if err != nil {
 			return errors.Wrap(err, msg)
@@ -223,21 +223,21 @@ func (c *Client) httpPOST(backOff backoff.BackOff, url string, body interface{},
 // httpDELETE sends a DELETE request. On errors httpDELETE expects a response body to contain
 // an error message in the format of application/problem+json.
 func (c *Client) httpDELETE(backOff backoff.BackOff, url, msg string) error {
-	request, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return errors.Wrapf(err, "%s: unable to prepare request", msg)
-	}
-
-	if c.tokenProvider != nil {
-		token, err := c.tokenProvider()
-		if err != nil {
-			return errors.Wrapf(err, "%s: unable to prepare request", msg)
-		}
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
-
 	var response *http.Response
-	err = backoff.Retry(func() error {
+	err := backoff.Retry(func() error {
+		request, err := http.NewRequest("DELETE", url, nil)
+		if err != nil {
+			return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+		}
+
+		if c.tokenProvider != nil {
+			token, err := c.tokenProvider()
+			if err != nil {
+				return backoff.Permanent(errors.Wrapf(err, "%s: unable to prepare request", msg))
+			}
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		response, err = c.httpClient.Do(request)
 		if err != nil {
 			return errors.Wrap(err, msg)

--- a/nakadi.go
+++ b/nakadi.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	defaultTimeOut              = 30 * time.Second
-	defaultNakadiURL            = "http://localhost:8080"
 	defaultInitialRetryInterval = time.Millisecond * 10
 	defaultMaxRetryInterval     = 10 * time.Second
 	defaultMaxElapsedTime       = 30 * time.Second

--- a/nakadi_test.go
+++ b/nakadi_test.go
@@ -13,6 +13,10 @@ import (
 	"gopkg.in/jarcoal/httpmock.v1"
 )
 
+const (
+	defaultNakadiURL = "http://localhost:8080"
+)
+
 func TestNew(t *testing.T) {
 	t.Run("with timeout", func(t *testing.T) {
 		timeout := 5 * time.Second

--- a/simple_stream.go
+++ b/simple_stream.go
@@ -8,11 +8,10 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-
 	"net/url"
+	"strconv"
 
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 // simpleStreamOpener implements the streamOpener interface.
@@ -29,6 +28,7 @@ func (so *simpleStreamOpener) openStream() (streamer, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create request")
 	}
+
 	if so.client.tokenProvider != nil {
 		token, err := so.client.tokenProvider()
 		if err != nil {
@@ -61,7 +61,6 @@ func (so *simpleStreamOpener) openStream() (streamer, error) {
 func (so *simpleStreamOpener) streamURL(id string) string {
 	queryParams := url.Values{}
 	if so.batchLimit > 0 {
-
 		queryParams.Add("batch_limit", strconv.FormatUint(uint64(so.batchLimit), 10))
 	}
 	if so.flushTimeout > 0 {


### PR DESCRIPTION
Instead of reusing request instances for retries, requests are now recreated in each retry.

Fixes #31 