### PR TITLE
Fix infinite loop in streamAPI.openStream

### DIFF
--- a/streams.go
+++ b/streams.go
@@ -179,7 +179,12 @@ func (s *StreamAPI) startStream() {
 		}, streamBackOff, s.notifyErr)
 
 		if err != nil {
-			continue
+			select {
+			case <-s.ctx.Done():
+				return
+			default:
+				continue
+			}
 		}
 		s.notifyOK()
 


### PR DESCRIPTION
This PR fixes #37 by checking if the streamAPI has been closed before trying to open the stream again. I also added a test that reveals the issue, including the nondeterministic select.