### PR TITLE
fixed calls of NotifyErr callback in the Processor

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -209,15 +209,17 @@ func (p *Processor) startSingleStream(operation Operation, streamNo int, options
 
 			err = operation(streamNo, cursor.NakadiStreamID, events)
 			if err != nil {
-				err = stream.Close()
-				if err != nil {
-					options.NotifyErr(err, 0)
-				}
+				options.NotifyErr(err, 0)
+				stream.Close()
 				stream = p.newStream(p.client, p.subscriptionID, &options)
 				continue
 			}
 
-			stream.CommitCursor(cursor)
+			err = stream.CommitCursor(cursor)
+			if err != nil {
+				options.NotifyErr(err, 0)
+				stream.Close()
+			}
 		}
 
 		elapsed := time.Since(start)


### PR DESCRIPTION
fixed calls of NotifyErr callback in the Processor
Fixes #46 

**Note** about removing of options from assertion of called arguments in mock:
as we currently hit NotifyErr and NotifyOk functions in the tests and they are not nil - DeepEqual [fails](https://golang.org/src/reflect/deepequal.go?#L145) inside `mock.Called`  function