### PR TITLE
Add timeout to ReadLine call so that it closes response body for dead tcp connections

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	// defaults used by http.DefaultTransport
-	defaultKeepAlive        = 30 * time.Second
-	defaultIdleConnTimeout  = 90 * time.Second
+	defaultKeepAlive       = 30 * time.Second
+	defaultIdleConnTimeout = 90 * time.Second
 	// nakadi specific timeouts
 	nakadiHeartbeatInterval = 30 * time.Second
 )
@@ -43,6 +43,7 @@ func newHTTPStream(timeout time.Duration) *http.Client {
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
 				Timeout:   timeout,
+				KeepAlive: 2 * nakadiHeartbeatInterval,
 				DualStack: true,
 			}).DialContext,
 			MaxIdleConns:        100,

--- a/simple_stream.go
+++ b/simple_stream.go
@@ -122,7 +122,7 @@ func (s *simpleStream) nextEvents() (Cursor, []byte, error) {
 }
 
 func (s *simpleStream) readLineTimeout() ([]byte, bool, error) {
-	timer := time.AfterFunc(s.readTimeout, func() { s.closeStream() })
+	timer := time.AfterFunc(s.readTimeout, func() { s.closer.Close() })
 	defer timer.Stop()
 	return s.buffer.ReadLine()
 }


### PR DESCRIPTION
Add timeout to ReadLine call so that it closes response body for dead tcp connections.
should fix #52 