### PR TITLE
Add annotations for the Nakadi subscriptions

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -31,6 +31,7 @@ type Subscription struct {
 	ReadFrom          string                     `json:"read_from,omitempty"`
 	CreatedAt         time.Time                  `json:"created_at,omitempty"`
 	Authorization     *SubscriptionAuthorization `json:"authorization,omitempty"`
+	Annotations       map[string]string          `json:"annotations,omitempty"`
 }
 
 // SubscriptionOptions is a set of optional parameters used to configure the SubscriptionAPI.


### PR DESCRIPTION
**Summary**
This pull request introduces a valuable enhancement to the project by adding a new field, annotation, to the subscription object. The absence of this field is currently causing minor operational issues, and the addition of this feature is aimed at addressing and resolving these concerns.

**Changes Made**
I have extended the subscription object to include the `annotations` field. This enhancement provides a solution for the issues encountered in the absence of this critical information.

**Problem Statement**
In the current configuration of my project, specifically with configuration maps for subscriptions, there is an absence of a defined lifecycle for subscriptions. This lack of a lifecycle poses challenges, especially in managing subscriptions for the PR environment.

**Solution Proposed**
With the introduction of the annotation field, I have laid the groundwork for resolving these issues. This new field allows the configuration of `janitor/ttl`, enabling the setting of lifetimes for subscriptions. This enhancement provides a flexible and effective solution to manage the lifecycle of subscriptions, including those in the PR environment.

**Benefits**
Issue Resolution: Addresses the minor issues caused by the absence of the annotation field.
Lifecycle Management: Enables the setting of lifetimes for subscriptions, enhancing control and management.

**Additional Notes**
Feel free to review and provide feedback. I am open to discussions and further improvements to ensure the seamless integration of this enhancement into the project.